### PR TITLE
do not use "latest" field

### DIFF
--- a/__tests__/installer.test.ts
+++ b/__tests__/installer.test.ts
@@ -34,8 +34,10 @@ describe("installer", () => {
   it("gets latest", async () => {
     const macos = await installer.getRelease("latest", "macos", "x86_64");
     const linux = await installer.getRelease("latest", "linux", "x86_64");
+    const win = await installer.getRelease("latest", "win", "x86_64");
     expect(macos).toBeDefined();
     expect(linux).toBeDefined();
+    expect(win).toBeDefined();
   });
   it("gets 2020.02.1 build rev 2 for win release", async () => {
     const win = await installer.getRelease("2020.02.1", "win", "x86_64");

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -30,17 +30,18 @@ export async function getRelease(
   arch: "x86_64"
 ): Promise<Release | null> {
   const releases = (await getAllReleases())
-    .filter(r => {
-      return (
+    .filter(
+      r =>
         r.arch === arch &&
         r.type === "archive" &&
         r.backend === "moar" &&
         r.platform === platform &&
-        (version === "latest" ? r.latest === 1 : r.ver === version)
-      );
-    })
+        (version === "latest" ? true : r.ver === version)
+    )
     .sort((r1, r2) => {
-      if (r2.build_rev === null && r1.build_rev === null) {
+      if (r1.ver !== r2.ver) {
+        return r1.ver < r2.ver ? 1 : -1;
+      } else if (r2.build_rev === null && r1.build_rev === null) {
         return 0;
       } else if (r1.build_rev === null) {
         return 1;


### PR DESCRIPTION
It happens that https://rakudo.org/dl/rakudo does not contain "latest" fields at all.
So do not depend on "latest" field. Sort releases by ourselves.