### PR TITLE
support macos arm64

### DIFF
--- a/__tests__/installer.test.ts
+++ b/__tests__/installer.test.ts
@@ -25,9 +25,11 @@ describe("installer", () => {
   jest.setTimeout(30 * 1000); // 30sec
   it("gets latest", async () => {
     const macos = await installer.getRelease("latest", "macos", "x86_64");
+    const macos2 = await installer.getRelease("latest", "macos", "arm64");
     const linux = await installer.getRelease("latest", "linux", "x86_64");
     const win = await installer.getRelease("latest", "win", "x86_64");
     expect(macos).toBeDefined();
+    expect(macos2).toBeDefined();
     expect(linux).toBeDefined();
     expect(win).toBeDefined();
   });

--- a/dist/index.js
+++ b/dist/index.js
@@ -172,7 +172,8 @@ function run() {
                 : os.platform() === "win32"
                     ? "win"
                     : "linux";
-            yield installer.getRaku(version, platform, "x86_64");
+            const arch = os.arch() === "arm64" ? "arm64" : "x86_64";
+            yield installer.getRaku(version, platform, arch);
             core.startGroup("raku -V");
             yield exec.exec("raku", ["-V"]);
             core.endGroup();

--- a/lib/main.js
+++ b/lib/main.js
@@ -46,7 +46,8 @@ function run() {
                 : os.platform() === "win32"
                     ? "win"
                     : "linux";
-            yield installer.getRaku(version, platform, "x86_64");
+            const arch = os.arch() === "arm64" ? "arm64" : "x86_64";
+            yield installer.getRaku(version, platform, arch);
             core.startGroup("raku -V");
             yield exec.exec("raku", ["-V"]);
             core.endGroup();

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -28,7 +28,7 @@ export async function getAllReleases(): Promise<Release[]> {
 export async function getRelease(
   version: string,
   platform: "win" | "macos" | "linux",
-  arch: "x86_64"
+  arch: "x86_64" | "arm64"
 ): Promise<Release | null> {
   const releases = (await getAllReleases())
     .filter(
@@ -58,7 +58,7 @@ export async function getRelease(
 export async function getRaku(
   version: string,
   platform: "win" | "macos" | "linux",
-  arch: "x86_64"
+  arch: "x86_64" | "arm64"
 ): Promise<void> {
   const release = await getRelease(version, platform, arch);
   if (release === null) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,8 @@ export async function run(): Promise<void> {
         : os.platform() === "win32"
         ? "win"
         : "linux";
-    await installer.getRaku(version, platform, "x86_64");
+    const arch = os.arch() === "arm64" ? "arm64" : "x86_64";
+    await installer.getRaku(version, platform, arch);
 
     core.startGroup("raku -V");
     await exec.exec("raku", ["-V"]);


### PR DESCRIPTION
See https://github.com/skaji/raku-Acme-Test-Module-Zef/actions/runs/8453195397/job/23155341360
```
2024-03-27T14:11:48.1040230Z ##[group]Run Raku/setup-raku@macos-arm64
2024-03-27T14:11:48.1040530Z with:
2024-03-27T14:11:48.1040680Z   raku-version: latest
2024-03-27T14:11:48.1040850Z ##[endgroup]
2024-03-27T14:11:48.9766560Z Downloading rakudo 2024.02 from https://rakudo.org/dl/rakudo/rakudo-moar-2024.02-01-macos-arm64-clang.tar.gz
2024-03-27T14:11:51.7384780Z Extracting archive
2024-03-27T14:11:51.7516970Z [command]/usr/bin/tar xz -C /Users/runner/work/_temp/335fce98-cd6e-4d06-bcef-dffd32dc7ef7 -f /Users/runner/work/_temp/bcd45f11-1664-4a53-ae03-60cee69860c9
2024-03-27T14:11:52.4103210Z Successfully installed rakudo into /Users/runner/hostedtoolcache/rakudo/2024.02-01/arm64
2024-03-27T14:11:52.4302290Z ##[group]raku -V
2024-03-27T14:11:52.4664980Z [command]/Users/runner/hostedtoolcache/rakudo/2024.02-01/arm64/bin/raku -V
2024-03-27T14:11:52.6685820Z Raku::can-language-versions=1 2 2.PREVIEW 2.TEST 2.TESTDEPR 3 3.PREVIEW
2024-03-27T14:11:52.6776870Z Raku::codename=
```